### PR TITLE
[FEATURE] Added MigrateBodytextFileLinksCommandController to copy files linked in RTE to the news import folder and replace the link with new uid

### DIFF
--- a/Classes/Command/MigrateBodytextFileLinksCommandController.php
+++ b/Classes/Command/MigrateBodytextFileLinksCommandController.php
@@ -1,0 +1,190 @@
+<?php
+namespace BeechIt\NewsTtnewsimport\Command;
+
+use GeorgRinger\News\Utility\EmConfiguration;
+use TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException;
+use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
+use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
+
+/**
+ * Class MigrateRteFileLinksCommandController
+ */
+class MigrateBodytextFileLinksCommandController extends CommandController
+{
+    /**
+     * @var \GeorgRinger\News\Domain\Model\Dto\EmConfiguration
+     */
+    protected $emSettings;
+
+    /**
+     * @var \TYPO3\CMS\Core\Resource\Folder
+     */
+    protected $importFolder;
+
+    /**
+     * @var string
+     */
+    protected $regularExpression = '#
+            (?\'tag\'<link\\s++(?\'typolink\'[^>]+)>)
+            (?\'content\'(?:[^<]++|<(?!/link>))*+)
+            </link>
+            #xumsi';
+
+    /**
+     * @var string
+     */
+    protected $tableName = 'tx_news_domain_model_news';
+
+    /**
+     * Migrate
+     */
+    public function migrateCommand()
+    {
+        $this->emSettings = EmConfiguration::getSettings();
+
+        $newsRecords = $this->getDatabaseConnection()->exec_SELECTgetRows(
+            'uid,bodytext',
+            $this->tableName,
+            ''
+        );
+        foreach ($newsRecords as $record) {
+            $bodytext = $record['bodytext'];
+            if (stripos($bodytext, '<link') !== false || stripos($bodytext, '&lt;link') !== false) {
+                $bodytext = preg_replace_callback(
+                    $this->regularExpression,
+                    function ($matches) {
+                        if ($this->isValidFileLink($matches['typolink'])) {
+                            preg_match('/file:([\d]+)/', $matches['typolink'], $uidMatches);
+
+                            if (isset($uidMatches[1])) {
+                                $file = $this->getOldFile($uidMatches[1]);
+
+                                if ($file instanceof FileInterface) {
+                                    $existingFile = $this->getExistingFile($file);
+                                    $replaceFile = $existingFile instanceof FileInterface
+                                        ? $existingFile : $this->copyFile($file);
+                                    if ($replaceFile instanceof FileInterface) {
+                                        return str_replace(
+                                            'file:' . $uidMatches[1],
+                                            'file:' . $replaceFile->getUid(),
+                                            $matches[0]
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        return $matches[0];
+                    },
+                    $bodytext
+                );
+                if ($bodytext !== $record['bodytext']) {
+                    $this->getDatabaseConnection()->exec_UPDATEquery(
+                        $this->tableName,
+                        'uid=' . $record['uid'],
+                        ['bodytext' => $bodytext]
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $link
+     * @return bool
+     */
+    protected function isValidFileLink($link)
+    {
+        return strpos($link, 'file:') === 0 && strpos($link, 'file://') === false;
+    }
+
+    /**
+     * @param $uid
+     * @return \TYPO3\CMS\Core\Resource\File|\TYPO3\CMS\Core\Resource\FileInterface|\TYPO3\CMS\Core\Resource\Folder|\TYPO3\CMS\Core\Resource\ProcessedFile|null
+     */
+    protected function getOldFile($uid)
+    {
+        try {
+            return $this->getResourceFactory()->retrieveFileOrFolderObject($uid);
+        } catch (FileDoesNotExistException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param $file
+     * @return \TYPO3\CMS\Core\Resource\File|\TYPO3\CMS\Core\Resource\FileInterface|\TYPO3\CMS\Core\Resource\Folder|\TYPO3\CMS\Core\Resource\ProcessedFile|null
+     */
+    protected function getExistingFile($file)
+    {
+        try {
+            return $this->getResourceFactory()->retrieveFileOrFolderObject(
+                rtrim($this->getImportFolderIdentifier(), '/') . '/' . $file->getName()
+            );
+        } catch (ResourceDoesNotExistException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param $file
+     * @return \TYPO3\CMS\Core\Resource\FileInterface|null
+     * @throws \TYPO3\CMS\Core\Resource\Exception\AbstractFileOperationException
+     * @throws \TYPO3\CMS\Core\Resource\Exception\ExistingTargetFileNameException
+     */
+    protected function copyFile($file)
+    {
+        try {
+            return $this->getResourceStorage()->copyFile(
+                $file,
+                $this->getImportFolder()
+            );
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Resource\Folder
+     */
+    protected function getImportFolder()
+    {
+        if ($this->importFolder === null) {
+            $this->importFolder = $this->getResourceFactory()->getFolderObjectFromCombinedIdentifier($this->getImportFolderIdentifier());
+        }
+        return $this->importFolder;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getImportFolderIdentifier()
+    {
+        return $this->emSettings->getStorageUidImporter() . ':' . $this->emSettings->getResourceFolderImporter();
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Resource\ResourceStorage|null
+     */
+    protected function getResourceStorage()
+    {
+        return $this->getResourceFactory()->getStorageObject($this->emSettings->getStorageUidImporter());
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Resource\ResourceFactory
+     */
+    protected function getResourceFactory()
+    {
+        return ResourceFactory::getInstance();
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Database\DatabaseConnection
+     */
+    protected function getDatabaseConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,4 +6,5 @@ if (!defined('TYPO3_MODE')) {
 if (TYPO3_MODE === 'BE') {
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = 'BeechIt\\NewsTtnewsimport\\Command\\TtNewsPluginMigrateCommandController';
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = 'BeechIt\\NewsTtnewsimport\\Command\\MigrateEventFieldsCommandController';
+	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = 'BeechIt\\NewsTtnewsimport\\Command\\MigrateBodytextFileLinksCommandController';
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -22,6 +22,6 @@ CREATE TABLE tx_news_domain_model_news (
 	tx_aunewsevent_preview_end int(11) DEFAULT '0' NOT NULL,
 	tx_aunewsevent_preview_hash varchar(255) DEFAULT '' NOT NULL,
 	tx_aunewsevent_showyear tinyint(4) DEFAULT '0' NOT NULL,
-	tx_lfaunewsserver_emne int(11) DEFAULT '0' NOT NULL,
+	tx_lfaunewsserver_emne text NOT NULL,
 	tx_rgnewsimg_design int(11) DEFAULT '0' NOT NULL
 );


### PR DESCRIPTION
Added a CommandController which checks if there are `<link file:...>` links present within the bodytext of news.
If so, copy the file to the news import folder and adjust the file link to the new uid.

Technical steps:
- A preg_match_callback on all links within the bodytext
- Check to see if it's a file link
- Get the old/current file link
- Check if the file is already available within the news import folder
- If file is not within the news_import, copy the file and return the adjusted file link
- If bodytext has been changed, update the news record